### PR TITLE
fix: Support multi-word queries

### DIFF
--- a/catalog/queries/nmvw.rq
+++ b/catalog/queries/nmvw.rq
@@ -10,33 +10,31 @@ CONSTRUCT {
     skos:narrower ?narrower_label .
 }
 WHERE {
-  {
-      ?uri skos:prefLabel ?label .
-      ?label <bif:contains> ?query
-  }
-  UNION {
-      ?uri skos:altLabel ?label .
-      ?label <bif:contains> ?query
-  }
-  OPTIONAL {
-      ?uri skos:prefLabel ?prefLabel .
-  }
-  OPTIONAL {
-      ?uri skos:scopeNote ?scopeNote .
-  }
-  OPTIONAL {
-      ?uri skos:altLabel ?altLabel .
-  }
-  OPTIONAL {
-      ?uri skos:hiddenLabel ?hiddenLabel .
-  }
-  OPTIONAL {
-      ?uri skos:broader ?uri_broader .
-      ?uri_broader skos:prefLabel ?broader_label .
-  }
-  OPTIONAL {
-      ?uri skos:narrower ?uri_narrower .
-      ?uri_narrower skos:prefLabel ?narrower_label .
-  }
+    ?uri ?predicate ?label .
+    VALUES ?predicate {  skos:prefLabel skos:altLabel }
+
+    # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
+    FILTER (<bif:contains> (?label, REPLACE(?query, "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)", " AND ", "i")))
+
+    OPTIONAL {
+        ?uri skos:prefLabel ?prefLabel .
+    }
+    OPTIONAL {
+        ?uri skos:scopeNote ?scopeNote .
+    }
+    OPTIONAL {
+        ?uri skos:altLabel ?altLabel .
+    }
+    OPTIONAL {
+        ?uri skos:hiddenLabel ?hiddenLabel .
+    }
+    OPTIONAL {
+        ?uri skos:broader ?uri_broader .
+        ?uri_broader skos:prefLabel ?broader_label .
+    }
+    OPTIONAL {
+        ?uri skos:narrower ?uri_narrower .
+        ?uri_narrower skos:prefLabel ?narrower_label .
+    }
 }
 LIMIT 1000

--- a/catalog/queries/nta.rq
+++ b/catalog/queries/nta.rq
@@ -8,20 +8,12 @@ CONSTRUCT {
 WHERE {
     GRAPH <http://data.bibliotheken.nl/thesp/> {
         ?uri a schema:Person .
-        {
-            ?uri rdfs:label ?label .
-            ?label <bif:contains> ?query
-        }
-        UNION
-        {
-            ?uri schema:name ?label .
-            ?label <bif:contains> ?query
-        }
-        UNION
-        {
-            ?uri schema:alternateName ?label .
-            ?label <bif:contains> ?query
-        }
+        ?uri ?predicate ?label .
+        VALUES ?predicate { rdfs:label schema:name schema:alternateName }
+
+        # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
+        FILTER (<bif:contains> (?label, REPLACE(?query, "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)", " AND ", "i")))
+
         OPTIONAL { ?uri rdfs:label ?rdfs_label }
         OPTIONAL { ?uri rdfs:comment ?rdfs_comment }
         OPTIONAL { ?uri schema:name ?schema_name }

--- a/catalog/queries/rkdartists.rq
+++ b/catalog/queries/rkdartists.rq
@@ -10,15 +10,12 @@ CONSTRUCT {
 WHERE {
     ?uri a ?type .
     VALUES ?type { schema:Person schema:Organization }
-    {
-        ?uri schema:name ?label .
-        ?label <bif:contains> ?query
-    }
-    UNION
-    {
-        ?uri schema:alternateName ?label .
-        ?label <bif:contains> ?query
-    }
+    ?uri ?name ?label .
+    VALUES ?name { schema:name schema:alternateName }
+
+    # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
+    FILTER (<bif:contains> (?label, REPLACE(?query, "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)", " AND ", "i")))
+
     OPTIONAL { ?uri schema:name ?schema_name . }
     OPTIONAL { ?uri schema:alternateName ?schema_alternateName . }
     OPTIONAL { ?uri schema:description ?schema_description . }


### PR DESCRIPTION
* This is a short-term solution to support queries to NMVW, NTA and RKDArtists 
  that multiple words. It follows our current paradigm of differentiating query requests
  in the SPARQL query itself.
* Use a regex to transform multi-word queries by connecting the words with 
  boolean operator `AND`, so `A B` becomes `A AND B`. This way, we get more 
  results than just quoting the query (`'A B'`).
* Fix netwerk-digitaal-erfgoed/network-of-terms-comunica#11.
* Ref netwerk-digitaal-erfgoed/network-of-terms-comunica#14.
* Simplify `UNION` queries using `VALUES`.