### PR TITLE
feat: Identify datasets by distribution IRI

### DIFF
--- a/catalog/aat.jsonld
+++ b/catalog/aat.jsonld
@@ -2,21 +2,22 @@
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
   "@id": "http://vocab.getty.edu/aat",
   "@type": "Dataset",
-  "identifier": "aat",
   "name": [
     {
       "@language": "en",
       "@value": "Art & Architecture Thesaurus (AAT)"
     }
   ],
-  "distribution": {
-    "@id": "http://vocab.getty.edu/aat/sparql",
-    "@type": "DataDownload",
-    "contentUrl": "http://vocab.getty.edu/sparql",
-    "encodingFormat": "application/sparql-query",
-    "potentialAction": {
-      "@type": "SearchAction",
-      "query": "file://queries/aat.rq"
+  "distribution": [
+    {
+      "@id": "http://vocab.getty.edu/aat/sparql",
+      "@type": "DataDownload",
+      "contentUrl": "http://vocab.getty.edu/sparql",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "query": "file://queries/aat.rq"
+      }
     }
-  }
+  ]
 }

--- a/catalog/cht.jsonld
+++ b/catalog/cht.jsonld
@@ -2,20 +2,22 @@
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
   "@id": "https://data.cultureelerfgoed.nl/term/id/cht",
   "@type": "Dataset",
-  "identifier": "cht",
   "name": [
     {
       "@language": "nl",
       "@value": "Cultuurhistorische Thesaurus (CHT)"
     }
   ],
-  "distribution": {
-    "@type": "DataDownload",
-    "contentUrl": "https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht",
-    "encodingFormat": "application/sparql-query",
-    "potentialAction": {
-      "@type": "SearchAction",
-      "query": "file://queries/cht.rq"
+  "distribution": [
+    {
+      "id": "https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht",
+      "@type": "DataDownload",
+      "contentUrl": "https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "query": "file://queries/cht.rq"
+      }
     }
-  }
+  ]
 }

--- a/catalog/cht.jsonld
+++ b/catalog/cht.jsonld
@@ -10,7 +10,7 @@
   ],
   "distribution": [
     {
-      "id": "https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht",
+      "@id": "https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht",
       "@type": "DataDownload",
       "contentUrl": "https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht",
       "encodingFormat": "application/sparql-query",

--- a/catalog/nmvw.jsonld
+++ b/catalog/nmvw.jsonld
@@ -2,21 +2,22 @@
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
   "@id": "https://data.netwerkdigitaalerfgoed.nl/NMVW/thesaurus",
   "@type": "Dataset",
-  "identifier": "nmvw",
   "name": [
     {
       "@language": "nl",
       "@value": "Thesaurus Nationaal Museum van Wereldculturen"
     }
   ],
-  "distribution": {
-    "@id": "https://data.netwerkdigitaalerfgoed.nl/NMVW/thesaurus/sparql",
-    "@type": "DataDownload",
-    "contentUrl": "https://api.data.netwerkdigitaalerfgoed.nl/datasets/nmvw/thesaurus/services/thesaurus/sparql",
-    "encodingFormat": "application/sparql-query",
-    "potentialAction": {
-      "@type": "SearchAction",
-      "query": "file://queries/nmvw.rq"
+  "distribution": [
+    {
+      "@id": "https://data.netwerkdigitaalerfgoed.nl/NMVW/thesaurus/sparql",
+      "@type": "DataDownload",
+      "contentUrl": "https://api.data.netwerkdigitaalerfgoed.nl/datasets/nmvw/thesaurus/services/thesaurus/sparql",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "query": "file://queries/nmvw.rq"
+      }
     }
-  }
+  ]
 }

--- a/catalog/nta.jsonld
+++ b/catalog/nta.jsonld
@@ -2,21 +2,22 @@
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
   "@id": "http://data.bibliotheken.nl/id/dataset/persons",
   "@type": "Dataset",
-  "identifier": "nta",
   "name": [
     {
       "@language": "nl",
       "@value": "Nederlandse Thesaurus voor Auteursnamen (NTA)"
     }
   ],
-  "distribution": {
-    "@id": "http://data.bibliotheken.nl/thesp/sparql",
-    "@type": "DataDownload",
-    "contentUrl": "http://data.bibliotheken.nl/sparql",
-    "encodingFormat": "application/sparql-query",
-    "potentialAction": {
-      "@type": "SearchAction",
-      "query": "file://queries/nta.rq"
+  "distribution": [
+    {
+      "@id": "http://data.bibliotheken.nl/thesp/sparql",
+      "@type": "DataDownload",
+      "contentUrl": "http://data.bibliotheken.nl/sparql",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "query": "file://queries/nta.rq"
+      }
     }
-  }
+  ]
 }

--- a/catalog/rkdartists.jsonld
+++ b/catalog/rkdartists.jsonld
@@ -2,21 +2,22 @@
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
   "@id": "https://data.rkd.nl/rkdartists",
   "@type": "Dataset",
-  "identifier": "rkdartists",
   "name": [
     {
       "@language": "en",
       "@value": "RKDartists"
     }
   ],
-  "distribution": {
-    "@id": "https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql",
-    "@type": "DataDownload",
-    "contentUrl": "https://api.data.netwerkdigitaalerfgoed.nl/datasets/rkd/rkdartists/services/rkdartists/sparql",
-    "encodingFormat": "application/sparql-query",
-    "potentialAction": {
-      "@type": "SearchAction",
-      "query": "file://queries/rkdartists.rq"
+  "distribution": [
+    {
+      "@id": "https://data.netwerkdigitaalerfgoed.nl/rkd/rkdartists/sparql",
+      "@type": "DataDownload",
+      "contentUrl": "https://api.data.netwerkdigitaalerfgoed.nl/datasets/rkd/rkdartists/services/rkdartists/sparql",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "query": "file://queries/rkdartists.rq"
+      }
     }
-  }
+  ]
 }

--- a/catalog/wikidata-entities.jsonld
+++ b/catalog/wikidata-entities.jsonld
@@ -2,21 +2,22 @@
   "@context": "https://schema.org/docs/jsonldcontext.jsonld",
   "@id": "https://www.wikidata.org",
   "@type": "Dataset",
-  "identifier": "wikidata-entities",
   "name": [
     {
       "@language": "en",
       "@value": "Wikidata Entities"
     }
   ],
-  "distribution": {
-    "@id": "https://www.wikidata.org/sparql",
-    "@type": "DataDownload",
-    "contentUrl": "https://query.wikidata.org/sparql",
-    "encodingFormat": "application/sparql-query",
-    "potentialAction": {
-      "@type": "SearchAction",
-      "query": "file://queries/wikidata-entities.rq"
+  "distribution": [
+    {
+      "@id": "https://www.wikidata.org/sparql",
+      "@type": "DataDownload",
+      "contentUrl": "https://query.wikidata.org/sparql",
+      "encodingFormat": "application/sparql-query",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "query": "file://queries/wikidata-entities.rq"
+      }
     }
-  }
+  ]
 }

--- a/shacl/dataset.jsonld
+++ b/shacl/dataset.jsonld
@@ -24,7 +24,10 @@
           "sh:class": {
             "@id": "schema:DataDownload"
           },
-          "sh:node": "schema:DistributionShape"
+          "sh:node": "schema:DistributionShape",
+          "sh:nodeKind": {
+            "@id": "sh:IRI"
+          }
         }
       ]
     },

--- a/shacl/dataset.jsonld
+++ b/shacl/dataset.jsonld
@@ -18,12 +18,6 @@
         },
         {
           "sh:path": {
-            "@id": "schema:identifier"
-          },
-          "sh:minCount": 1
-        },
-        {
-          "sh:path": {
             "@id": "schema:distribution"
           },
           "sh:minCount": 1,

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -45,6 +45,8 @@ describe('Catalog', () => {
     const distribution = wikidata.getDistributionByIri(distributionIri)!;
     expect(distribution).toBeInstanceOf(SparqlDistribution);
     expect(distribution.iri).toEqual(distributionIri);
-    expect(distribution.endpoint).toEqual(new IRI('https://query.wikidata.org/sparql'));
+    expect(distribution.endpoint).toEqual(
+      new IRI('https://query.wikidata.org/sparql')
+    );
   });
 });

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -27,7 +27,7 @@ describe('Catalog', () => {
     expect(catalog.datasets.length).toBe(6);
   });
 
-  it('can retrieve datasets by identifier', () => {
+  it('can retrieve datasets by IRI', () => {
     expect(
       catalog.getDatasetByDistributionIri(new IRI('https://nope.com'))
     ).toBeUndefined();
@@ -39,7 +39,7 @@ describe('Catalog', () => {
     expect(cht.name).toEqual('Cultuurhistorische Thesaurus (CHT)');
   });
 
-  it('can retrieve distributions by identifier', () => {
+  it('can retrieve distributions by IRI', () => {
     const distributionIri = new IRI('https://www.wikidata.org/sparql');
     const wikidata = catalog.getDatasetByDistributionIri(distributionIri)!;
     const distribution = wikidata.getDistributionByIri(distributionIri)!;

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -31,10 +31,9 @@ describe('Catalog', () => {
     expect(
       catalog.getDatasetByDistributionIri(new IRI('https://nope.com'))
     ).toBeUndefined();
-    // eslint-disable-next-line @typescript-eslint/no-extra-non-null-assertion
     const cht = catalog.getDatasetByDistributionIri(
       new IRI('https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht')
-    )!!;
+    )!;
     expect(cht).toBeInstanceOf(Dataset);
     expect(cht.name).toEqual('Cultuurhistorische Thesaurus (CHT)');
   });

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -1,4 +1,10 @@
-import {Catalog, Dataset, fromFiles, IRI} from '../src/catalog';
+import {
+  Catalog,
+  Dataset,
+  fromFiles,
+  IRI,
+  SparqlDistribution,
+} from '../src/catalog';
 
 let catalog: Catalog;
 
@@ -23,13 +29,22 @@ describe('Catalog', () => {
 
   it('can retrieve datasets by identifier', () => {
     expect(
-      catalog.getByDistributionIri(new IRI('https://nope.com'))
+      catalog.getDatasetByDistributionIri(new IRI('https://nope.com'))
     ).toBeUndefined();
     // eslint-disable-next-line @typescript-eslint/no-extra-non-null-assertion
-    const cht = catalog.getByDistributionIri(
+    const cht = catalog.getDatasetByDistributionIri(
       new IRI('https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht')
     )!!;
     expect(cht).toBeInstanceOf(Dataset);
     expect(cht.name).toEqual('Cultuurhistorische Thesaurus (CHT)');
+  });
+
+  it('can retrieve distributions by identifier', () => {
+    const distributionIri = new IRI('https://www.wikidata.org/sparql');
+    const wikidata = catalog.getDatasetByDistributionIri(distributionIri)!;
+    const distribution = wikidata.getDistributionByIri(distributionIri)!;
+    expect(distribution).toBeInstanceOf(SparqlDistribution);
+    expect(distribution.iri).toEqual(distributionIri);
+    expect(distribution.endpoint).toEqual(new IRI('https://query.wikidata.org/sparql'));
   });
 });

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -1,4 +1,4 @@
-import {Catalog, fromFiles} from '../src/catalog';
+import {Catalog, Dataset, fromFiles, IRI} from '../src/catalog';
 
 let catalog: Catalog;
 
@@ -11,7 +11,7 @@ describe('Catalog', () => {
     const store = await fromFiles('catalog/');
     const catalog = await Catalog.fromStore(store);
     expect(catalog.datasets.length).toBe(6);
-    expect(catalog.datasets[0].distribution.query).toEqual(
+    expect(catalog.datasets[0].distributions[0].query).toEqual(
       expect.stringContaining('CONSTRUCT {')
     );
     done();
@@ -22,9 +22,14 @@ describe('Catalog', () => {
   });
 
   it('can retrieve datasets by identifier', () => {
-    expect(catalog.getByIdentifier('nope')).toBeUndefined();
+    expect(
+      catalog.getByDistributionIri(new IRI('https://nope.com'))
+    ).toBeUndefined();
     // eslint-disable-next-line @typescript-eslint/no-extra-non-null-assertion
-    const cht = catalog.getByIdentifier('cht')!!;
-    expect(cht.identifier).toEqual('cht');
+    const cht = catalog.getByDistributionIri(
+      new IRI('https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht')
+    )!!;
+    expect(cht).toBeInstanceOf(Dataset);
+    expect(cht.name).toEqual('Cultuurhistorische Thesaurus (CHT)');
   });
 });


### PR DESCRIPTION
* Fix netwerk-digitaal-erfgoed/network-of-terms-comunica#17.
* Remove dataset identifier.
* Make dataset distributions a list.

BREAKING CHANGE: `getByIdentifier()` was removed; call `getDatasetByDistributionIri()` instead.