### PR TITLE
Changed queries to also use URIs of broader and narrower terms

### DIFF
--- a/catalog/queries/aat.rq
+++ b/catalog/queries/aat.rq
@@ -9,39 +9,41 @@ PREFIX skosxl: <http://www.w3.org/2008/05/skos-xl#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
-    skos:prefLabel ?prefLabel ;
-    skos:altLabel ?altLabel ;
-    skos:scopeNote ?scopeNote ;
-    skos:broader ?broader_label ;
-    skos:narrower ?narrower_label .
+        skos:prefLabel ?prefLabel ;
+        skos:altLabel ?altLabel ;
+        skos:scopeNote ?scopeNote .
+    ?uri skos:broader ?broader_uri .
+    ?broader_uri skos:prefLabel ?broader_prefLabel .
+    ?uri skos:narrower ?narrower_uri .
+    ?narrower_uri skos:prefLabel ?narrower_prefLabel .
 }
 WHERE {
-    ?uri luc:term ?query;
-    a ?type .
+    ?uri luc:term ?query ;
+        a ?type .
     ?type rdfs:subClassOf gvp:Subject .
     FILTER (?type != gvp:Subject) .
-    ?uri skosxl:prefLabel ?uri_prefLabel .
-    ?uri_prefLabel dcterms:language aat:300388256 . # Dutch (language)
-    ?uri_prefLabel skosxl:literalForm ?prefLabel .
+    ?uri skosxl:prefLabel ?prefLabel_uri .
+    ?prefLabel_uri dcterms:language aat:300388256 . # Dutch (language)
+    ?prefLabel_uri skosxl:literalForm ?prefLabel .
     OPTIONAL {
-        ?uri skosxl:altLabel ?uri_altLabel .
-        ?uri_altLabel dcterms:language aat:300388256 .
-        ?uri_altLabel skosxl:literalForm ?altLabel .
+        ?uri skosxl:altLabel ?altLabel_uri .
+        ?altLabel_uri dcterms:language aat:300388256 .
+        ?altLabel_uri skosxl:literalForm ?altLabel .
     }
     OPTIONAL {
-        ?uri gvp:broaderPreferredExtended/skosxl:prefLabel ?uri_broader .
-        ?uri_broader dcterms:language aat:300388256 . # Dutch (language)
-        ?uri_broader skosxl:literalForm ?broader_label .
+        ?uri skos:scopeNote ?scopeNote_uri .
+        ?scopeNote_uri dcterms:language aat:300388256 . # Dutch (language)
+        ?scopeNote_uri rdf:value ?scopeNote .
     }
     OPTIONAL {
-        ?uri skos:scopeNote ?uri_scopeNote .
-        ?uri_scopeNote dcterms:language aat:300388256 . # Dutch (language)
-        ?uri_scopeNote rdf:value ?scopeNote .
+        ?uri gvp:broaderPreferredExtended/skosxl:prefLabel ?broader_uri .
+        ?broader_uri dcterms:language aat:300388256 . # Dutch (language)
+        ?broader_uri skosxl:literalForm ?broader_prefLabel .
     }
     OPTIONAL {
-        ?uri skos:narrower/skosxl:prefLabel ?uri_narrower .
-        ?uri_narrower dcterms:language aat:300388256 . # Dutch (language)
-        ?uri_narrower skosxl:literalForm ?narrower_label .
+        ?uri skos:narrower/skosxl:prefLabel ?narrower_uri .
+        ?narrower_uri dcterms:language aat:300388256 . # Dutch (language)
+        ?narrower_uri skosxl:literalForm ?narrower_prefLabel .
     }
 }
 LIMIT 1000

--- a/catalog/queries/cht.rq
+++ b/catalog/queries/cht.rq
@@ -2,36 +2,40 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
-    skos:prefLabel ?prefLabel ;
-    skos:altLabel ?altLabel ;
-    skos:hiddenLabel ?hiddenLabel ;
-    skos:scopeNote ?scopeNote ;
-    skos:broader ?broader_label ;
-    skos:narrower ?narrower_label .
+        skos:prefLabel ?prefLabel ;
+        skos:altLabel ?altLabel ;
+        skos:hiddenLabel ?hiddenLabel ;
+        skos:scopeNote ?scopeNote .
+    ?uri skos:broader ?broader_uri .
+    ?broader_uri skos:prefLabel ?broader_prefLabel .
+    ?uri skos:narrower ?narrower_uri .
+    ?narrower_uri skos:prefLabel ?narrower_prefLabel .
 }
 WHERE {
     ?uri skos:prefLabel ?prefLabel
     FILTER(LANG(?prefLabel) = "nl")
     FILTER(CONTAINS(LCASE(?prefLabel), LCASE(?query)))
     OPTIONAL {
-      ?uri skos:scopeNote ?scopeNote .
-      FILTER(LANG(?scopeNote) = "nl")
+        ?uri skos:scopeNote ?scopeNote .
+        FILTER(LANG(?scopeNote) = "nl")
     }
     OPTIONAL {
-      ?uri skos:altLabel ?altLabel .
-      FILTER(LANG(?altLabel) = "nl")
+        ?uri skos:altLabel ?altLabel .
+        FILTER(LANG(?altLabel) = "nl")
     }
     OPTIONAL {
-      ?uri skos:hiddenLabel ?hiddenLabel .
-      FILTER(LANG(?hiddenLabel) = "nl")
+        ?uri skos:hiddenLabel ?hiddenLabel .
+        FILTER(LANG(?hiddenLabel) = "nl")
     }
     OPTIONAL {
-      ?uri skos:broader/skos:prefLabel ?broader_label .
-      FILTER(LANG(?broader_label) = "nl")
+        ?uri skos:broader ?broader_uri .
+        ?broader_uri skos:prefLabel ?broader_prefLabel .
+        FILTER(LANG(?broader_prefLabel) = "nl")
     }
     OPTIONAL {
-      ?uri skos:narrower/skos:prefLabel ?narrower_label .
-      FILTER(LANG(?narrower_label) = "nl")
+        ?uri skos:narrower ?narrower_uri .
+        ?narrower_uri skos:prefLabel ?narrower_prefLabel .
+        FILTER(LANG(?narrower_prefLabel) = "nl")
     }
 }
 LIMIT 1000

--- a/catalog/queries/nmvw.rq
+++ b/catalog/queries/nmvw.rq
@@ -2,16 +2,18 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;
-    skos:prefLabel ?prefLabel ;
-    skos:altLabel ?altLabel ;
-    skos:hiddenLabel ?hiddenLabel ;
-    skos:scopeNote ?scopeNote ;
-    skos:broader ?broader_label ;
-    skos:narrower ?narrower_label .
+        skos:prefLabel ?prefLabel ;
+        skos:altLabel ?altLabel ;
+        skos:hiddenLabel ?hiddenLabel ;
+        skos:scopeNote ?scopeNote .
+    ?uri skos:broader ?broader_uri .
+    ?broader_uri skos:prefLabel ?broader_prefLabel .
+    ?uri skos:narrower ?narrower_uri .
+    ?narrower_uri skos:prefLabel ?narrower_prefLabel .
 }
 WHERE {
     ?uri ?predicate ?label .
-    VALUES ?predicate {  skos:prefLabel skos:altLabel }
+    VALUES ?predicate { skos:prefLabel skos:altLabel }
 
     # Replace query "A B" with "A AND B", leaving queries "A AND B" or "A OR B" unchanged.
     FILTER (<bif:contains> (?label, REPLACE(?query, "(?<!AND)(?<!OR)[[:space:]]+(?!AND)(?!OR)", " AND ", "i")))
@@ -29,12 +31,12 @@ WHERE {
         ?uri skos:hiddenLabel ?hiddenLabel .
     }
     OPTIONAL {
-        ?uri skos:broader ?uri_broader .
-        ?uri_broader skos:prefLabel ?broader_label .
+        ?uri skos:broader ?broader_uri .
+        ?broader_uri skos:prefLabel ?broader_prefLabel .
     }
     OPTIONAL {
-        ?uri skos:narrower ?uri_narrower .
-        ?uri_narrower skos:prefLabel ?narrower_label .
+        ?uri skos:narrower ?narrower_uri .
+        ?narrower_uri skos:prefLabel ?narrower_prefLabel .
     }
 }
 LIMIT 1000


### PR DESCRIPTION
@ddeboer Can you take a look at this PR? I've changed the SPARQL queries that use broader and narrower terms: the queries now not just return the labels of these terms, but also their URIs.

Warning: this obviously changes the results. If we merge this PR and use it in `network-of-terms-comunica`, that package won't function properly anymore. We first need to change the way the [TermsTransformer](https://github.com/netwerk-digitaal-erfgoed/network-of-terms-comunica/blob/master/src/services/terms.ts) works: it now assumes that the broader and narrower terms are literals rather than URIs and doesn't follow the URIs in order to lookup the prefLabels of the broader and narrower terms.