### PR TITLE
fix: Force SKOS prefix

### DIFF
--- a/catalog/queries/nta.rq
+++ b/catalog/queries/nta.rq
@@ -1,3 +1,5 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#> .
+
 CONSTRUCT {
     ?uri a skos:Concept ;
          skos:prefLabel ?rdfs_label ;


### PR DESCRIPTION
NTA returns term results with a SKOS prefix of <http://www.w3.org/2008/05/skos#>
whereas the skos:Concept selection in network-of-terms-api assumes
<http://www.w3.org/2004/02/skos/core#>.