### PR TITLE
fix: skos brinkman

### DIFF
--- a/catalog/queries/brinkman.rq
+++ b/catalog/queries/brinkman.rq
@@ -1,3 +1,5 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
 CONSTRUCT { 
   ?uri a skos:Concept ; 
        skos:prefLabel ?rdfs_label ; 


### PR DESCRIPTION
KB data uses and old version of SKOS - added  SKOS prefix explicitly