### PR TITLE
fix: retrieve direct broader term, not hierarchy of broader terms

### DIFF
--- a/catalog/queries/aat.rq
+++ b/catalog/queries/aat.rq
@@ -36,7 +36,7 @@ WHERE {
         ?scopeNote_uri rdf:value ?scopeNote .
     }
     OPTIONAL {
-        ?uri gvp:broaderPreferredExtended/skosxl:prefLabel ?broader_uri .
+        ?uri gvp:broaderPreferred/skosxl:prefLabel ?broader_uri .
         ?broader_uri dcterms:language aat:300388256 . # Dutch (language)
         ?broader_uri skosxl:literalForm ?broader_prefLabel .
     }


### PR DESCRIPTION
The old query retrieves the full hierarchy of broader terms: the broader term of the broader term of the broader term, etc. This is a-typical behavior (and also confusing to some users, I heard): the other NoT queries merely retrieve the direct broader term(s) of a term.