### PR TITLE
feat: Add URI lookup data to catalog

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   roots: ['test/'],
   preset: 'ts-jest',
-  testTimeout: 10000,
+  testTimeout: 20000,
   globals: {
     'ts-jest': {
       tsConfig: 'tsconfig.test.json',

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -90,6 +90,14 @@ export class Catalog {
       dataset => dataset.getDistributionByIri(iri) !== undefined
     );
   }
+
+  public getDatasetByTermIri(iri: IRI): Dataset | undefined {
+    return this.datasets.find(dataset =>
+      dataset.termsPrefixes.some(termPrefix =>
+        iri.toString().startsWith(termPrefix.toString())
+      )
+    );
+  }
 }
 
 export class Dataset {

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -72,9 +72,7 @@ export class Catalog {
                 bindings.get('?lookupQuery').value
               ),
             ],
-            bindings.get('?alternateName')
-              ? bindings.get('?alternateName').value
-              : undefined
+            bindings.get('?alternateName')?.value
           )
         );
       });

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -28,15 +28,16 @@ export class Catalog {
           ?dataset a schema:Dataset ;
             schema:name ?name ;
             schema:creator ?creator ;
-            schema:distribution ?distribution .
+            schema:distribution ?distribution ;
+            schema:url ?url .
           OPTIONAL { ?dataset schema:alternateName ?alternateName . }
           ?creator schema:name ?creatorName ;
             schema:alternateName ?creatorAlternateName .
           ?distribution schema:encodingFormat "application/sparql-query" ;
             schema:contentUrl ?endpointUrl ;
-            schema:potentialAction ?potentialAction .
-          ?potentialAction a schema:SearchAction ;
-            schema:query ?query .
+            schema:potentialAction 
+                [a schema:SearchAction ; schema:query ?searchQuery ] ,
+                [a schema:FindAction ; schema:query ?lookupQuery ] .
         }
         ORDER BY LCASE(?name)`;
     const result = (await newEngine().query(query, {
@@ -50,6 +51,7 @@ export class Catalog {
           new Dataset(
             new IRI(bindings.get('?dataset').value),
             bindings.get('?name').value,
+            new IRI(bindings.get('?url').value),
             [
               new Organization(
                 new IRI(bindings.get('?creator').value),
@@ -61,7 +63,8 @@ export class Catalog {
               new SparqlDistribution(
                 new IRI(bindings.get('?distribution').value),
                 new IRI(bindings.get('?endpointUrl').value),
-                bindings.get('?query').value
+                bindings.get('?searchQuery').value,
+                bindings.get('?lookupQuery').value
               ),
             ],
             bindings.get('?alternateName')
@@ -88,6 +91,7 @@ export class Dataset {
   constructor(
     readonly iri: IRI,
     readonly name: string,
+    readonly urlPrefix: IRI,
     readonly creators: [Organization],
     readonly distributions: [Distribution],
     readonly alternateName?: string
@@ -112,7 +116,8 @@ export class SparqlDistribution {
   constructor(
     readonly iri: IRI,
     readonly endpoint: IRI,
-    readonly query: string
+    readonly searchQuery: string,
+    readonly lookupQuery: string
   ) {}
 }
 

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -22,6 +22,7 @@ export class Catalog {
   }
 
   public static async fromStore(store: RDF.Store[]): Promise<Catalog> {
+    // Collect all properties for SELECT and GROUP BY so we can flatten the schema:url values into a single value.
     const properties =
       '?dataset ?name ?creator ?creatorName ?creatorAlternateName ?distribution ?endpointUrl ?searchQuery ?lookupQuery ?alternateName';
     const query = `
@@ -55,7 +56,7 @@ export class Catalog {
             bindings.get('?name').value,
             bindings
               .get('?url')
-              .value.split(' ')
+              .value.split(' ') // The single value is space-delineated.
               .map(url => new IRI(url)),
             [
               new Organization(

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -21,9 +21,9 @@ describe('Catalog', () => {
     )!;
     expect(cht).toBeInstanceOf(Dataset);
     expect(cht.name).toEqual('Cultuurhistorische Thesaurus');
-    expect(cht.termsPrefixes[0]).toEqual(
-      new IRI('https://data.cultureelerfgoed.nl/term/id/cht/')
-    );
+    expect(cht.termsPrefixes).toEqual([
+      new IRI('https://data.cultureelerfgoed.nl/term/id/cht/'),
+    ]);
     expect(cht.alternateName).toEqual('CHT');
     expect(cht.creators[0].name).toEqual(
       'Rijksdienst voor het Cultureel Erfgoed'
@@ -44,5 +44,16 @@ describe('Catalog', () => {
     );
     expect(distribution.searchQuery).toMatch(/CONSTRUCT/);
     expect(distribution.lookupQuery).toMatch(/CONSTRUCT/);
+  });
+
+  it('can retrieve dataset by term IRI', () => {
+    expect(
+      catalog.getDatasetByTermIri(new IRI('https://nope'))
+    ).toBeUndefined();
+    const rkd = catalog.getDatasetByTermIri(
+      new IRI('https://data.rkd.nl/artists/123')
+    );
+    expect(rkd).toBeInstanceOf(Dataset);
+    expect(rkd?.iri).toEqual(new IRI('https://data.rkd.nl/rkdartists'));
   });
 });

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -15,11 +15,15 @@ describe('Catalog', () => {
     expect(
       catalog.getDatasetByDistributionIri(new IRI('https://nope.com'))
     ).toBeUndefined();
+
     const cht = catalog.getDatasetByDistributionIri(
       new IRI('https://data.cultureelerfgoed.nl/PoolParty/sparql/term/id/cht')
     )!;
     expect(cht).toBeInstanceOf(Dataset);
     expect(cht.name).toEqual('Cultuurhistorische Thesaurus');
+    expect(cht.urlPrefix).toEqual(
+      new IRI('https://data.cultureelerfgoed.nl/term/id/cht/')
+    );
     expect(cht.alternateName).toEqual('CHT');
     expect(cht.creators[0].name).toEqual(
       'Rijksdienst voor het Cultureel Erfgoed'
@@ -38,5 +42,7 @@ describe('Catalog', () => {
     expect(distribution.endpoint).toEqual(
       new IRI('https://query.wikidata.org/sparql')
     );
+    expect(distribution.searchQuery).toMatch(/CONSTRUCT/);
+    expect(distribution.lookupQuery).toMatch(/CONSTRUCT/);
   });
 });

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -21,7 +21,7 @@ describe('Catalog', () => {
     )!;
     expect(cht).toBeInstanceOf(Dataset);
     expect(cht.name).toEqual('Cultuurhistorische Thesaurus');
-    expect(cht.urlPrefix).toEqual(
+    expect(cht.termsPrefixes[0]).toEqual(
       new IRI('https://data.cultureelerfgoed.nl/term/id/cht/')
     );
     expect(cht.alternateName).toEqual('CHT');


### PR DESCRIPTION
Fix #71.

BREAKING CHANGE: the `SparqlDistribution.query` property was renamed to
`searchQuery`.
