### PR TITLE
Limit results to AAT concepts

### DIFF
--- a/catalog/queries/search/aat.rq
+++ b/catalog/queries/search/aat.rq
@@ -19,7 +19,8 @@ CONSTRUCT {
 }
 WHERE {
     ?uri luc:term ?query ;
-        a ?type .
+        a ?type ;
+        void:inDataset <http://vocab.getty.edu/dataset/aat>  .
     ?type rdfs:subClassOf gvp:Subject .
     FILTER (?type != gvp:Subject) .
     ?uri skosxl:prefLabel ?prefLabel_uri .


### PR DESCRIPTION
Fixed aat.rq to limit results the results to concepts only coming from the AAT dataset.