### PR TITLE
fix: aat query

### DIFF
--- a/catalog/queries/search/aat.rq
+++ b/catalog/queries/search/aat.rq
@@ -6,6 +6,7 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX skosxl: <http://www.w3.org/2008/05/skos-xl#>
+PREFIX void: <http://rdfs.org/ns/void#>
 
 CONSTRUCT {
     ?uri a skos:Concept ;


### PR DESCRIPTION
The previous update missed a void prefix definition which leads to errors running AAT queries.